### PR TITLE
idea / eclipse / pgp plugins should be in global sbt config

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,16 +1,6 @@
 import Defaults._
 
-resolvers += Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
-resolvers += Classpaths.typesafeResolver
-
 resolvers += "scct-github-repository" at "http://mtkopone.github.com/scct/maven-repo"
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0")
-
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")
-
-addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
 
 libraryDependencies <<= (scalaVersion, libraryDependencies) {(version, dependencies) =>
   if (!version.startsWith("2.10"))


### PR DESCRIPTION
These plugins should be in your global sbt configuration (instead of directly in the project), because it is usually recommended to have these in the global sbt configuration, and sbt users who have may get clashes (as I do which makes contributing kinda painful, because I would have to edit my global sbt config):

```
[error] AttributeKey ID collisions detected for: 'pgp-signer' (sbt.Task[com.typesafe.sbt.pgp.PgpSigner], sbt.Task[com.jsuereth.pgp.sbtplugin.PgpSigner]), 'pgp-verifier' (sbt.Task[com.typesafe.sbt.pgp.PgpVerifier], sbt.Task[com.jsuereth.pgp.sbtplugin.PgpVerifier]), 'check-pgp-signatures' (sbt.Task[com.jsuereth.pgp.sbtplugin.SignatureCheckReport], sbt.Task[com.typesafe.sbt.pgp.SignatureCheckReport]), 'signatures-module' (sbt.Task[com.jsuereth.pgp.sbtplugin.GetSignaturesModule], sbt.Task[com.typesafe.sbt.pgp.GetSignaturesModule])
```

It is usually recommended to have certain plugins in your global configuration:
- the gpg plugin certainly, because only the owner who publishes needs it; it is usually useful to store your username (and password) in the global configuration, too; I have done this (and I figure most people who publish, too) that's the reason for the clash (although I'm using the newer "com.typesafe.sbt" % "sbt-pgp" % "0.7")
- also I would recommend to move both "sbt-idea" and "sbteclipse-plugin" to your global configuration, because it is really user specific which editor / IDE to use and it may also clash

I figure the general guideline is to have only those plugins in the global configuration who are needed to build the project and maintenance like scct.
