### PR TITLE
Fix to use "org.specs2" %% "specs2_2.9.2" % "1.12.2" % "test" 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,12 +34,11 @@ libraryDependencies <<= (scalaVersion, libraryDependencies) {(version, dependenc
   val specs2 =
     if (version.startsWith("2.10"))
       "org.specs2" %% "specs2" % "1.13" % "test"
+    // Because Specs 2 for Scala 2.9.3 is not published yet
+    else if (version == "2.9.3")
+      "org.specs2" %% "specs2_2.9.2" % "1.12.2" % "test"
     else
       "org.specs2" %% "specs2" % "1.12.2" % "test"
-  // Because Specs 2 for Scala 2.9.3 is not published yet
-  if (version == "2.9.3")
-    dependencies
-  else
     dependencies :+ specs2
 }
 


### PR DESCRIPTION
Since Scala 2.9.3 is almost binary compatible with Scala 2.9.2
