### PR TITLE
Fix `publishTo` URL from "http://...." to "https://"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,11 +83,11 @@ pomExtra := (
 )
 
 publishTo <<= version { v =>
-  val nexus = "http://oss.sonatype.org/"
+  val nexus = "https://oss.sonatype.org/"
   if (v.endsWith("-SNAPSHOT"))
-    Some("snapshots" at nexus+"content/repositories/snapshots")
+    Some("snapshots" at nexus + "content/repositories/snapshots")
   else
-    Some("releases" at nexus+"service/local/staging/deploy/maven2")
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
 credentials ++= {


### PR DESCRIPTION
- Now Sonatype OSS doesn't accept URL starts with 'http://' but 'https://'
