### PR TITLE
fixes #83

### DIFF
--- a/src/main/scala/com/github/nscala_time/time/RichInterval.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichInterval.scala
@@ -28,7 +28,7 @@ class RichInterval(val underlying: Interval) extends Super with PimpedType[Inter
 
     var x = underlying.getStart
 
-    while (x < underlying.getEnd) {
+    while (x <= underlying.getEnd) {
       builder += x
       x += period
     }

--- a/src/test/scala/RichIntervalSpec.scala
+++ b/src/test/scala/RichIntervalSpec.scala
@@ -17,4 +17,13 @@ object RichIntervalSpec extends Properties("RichInterval") with Imports {
     }
   }
 
+  property("by, coll.last == interval.end") = forAll(Gen.choose(1,1440)) { n =>
+    val start = DateTime.now
+    val end = start + n.minute
+
+    val coll = start to end by 1.minute
+
+    coll.last == end
+  }
+
 }


### PR DESCRIPTION
I chose `by 1.minute` because with it end is always contained in coll.