### PR TITLE
Add parentheses to mathods which are not purely-functional

### DIFF
--- a/src/main/scala/com/github/nscala_time/time/DurationBuilder.scala
+++ b/src/main/scala/com/github/nscala_time/time/DurationBuilder.scala
@@ -33,9 +33,9 @@ class DurationBuilder(val underlying: Period) extends Super {
   def -(that: DurationBuilder): DurationBuilder =
     DurationBuilder(this.underlying.minus(that.underlying))
 
-  def ago: DateTime =
+  def ago(): DateTime =
     StaticDateTime.now.minus(underlying)
-  def later: DateTime =
+  def later(): DateTime =
     StaticDateTime.now.plus(underlying)
   def from(dt: DateTime): DateTime =
     dt.plus(underlying)

--- a/src/main/scala/com/github/nscala_time/time/RichPeriod.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichPeriod.scala
@@ -45,9 +45,9 @@ class RichPeriod(val underlying: Period) extends Super with PimpedType[Period] {
 
   def *(scalar: Int): Period = underlying.multipliedBy(scalar)
 
-  def ago: DateTime = StaticDateTime.now.minus(underlying)
+  def ago(): DateTime = StaticDateTime.now.minus(underlying)
 
-  def later: DateTime = StaticDateTime.now.plus(underlying)
+  def later(): DateTime = StaticDateTime.now.plus(underlying)
 
   def from(dt: DateTime): DateTime = dt.plus(underlying)
 

--- a/src/main/scala/com/github/nscala_time/time/StaticDateTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticDateTime.scala
@@ -25,27 +25,27 @@ object StaticDateTime extends StaticDateTime
 trait StaticDateTime {
   type Property = DateTime.Property
 
-  def now        = new DateTime
+  def now()        = new DateTime
   def now(zone: DateTimeZone) = DateTime.now(zone)
   def now(chronology: Chronology) = DateTime.now(chronology)
   def parse(str: String) = DateTime.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = DateTime.parse(str, formatter)
 
-  def nextSecond = now + 1.second
-  def nextMinute = now + 1.minute
-  def nextHour   = now + 1.hour
-  def nextDay    = now + 1.day
-  def tomorrow   = now + 1.day
-  def nextWeek   = now + 1.week
-  def nextMonth  = now + 1.month
-  def nextYear   = now + 1.year
+  def nextSecond() = now + 1.second
+  def nextMinute() = now + 1.minute
+  def nextHour()   = now + 1.hour
+  def nextDay()    = now + 1.day
+  def tomorrow()   = now + 1.day
+  def nextWeek()   = now + 1.week
+  def nextMonth()  = now + 1.month
+  def nextYear()   = now + 1.year
 
-  def lastSecond = now - 1.second
-  def lastMinute = now - 1.minute
-  def lastHour   = now - 1.hour
-  def lastDay    = now - 1.day
-  def yesterday  = now - 1.day
-  def lastWeek   = now - 1.week
-  def lastMonth  = now - 1.month
-  def lastYear   = now - 1.year
+  def lastSecond() = now - 1.second
+  def lastMinute() = now - 1.minute
+  def lastHour()   = now - 1.hour
+  def lastDay()    = now - 1.day
+  def yesterday()  = now - 1.day
+  def lastWeek()   = now - 1.week
+  def lastMonth()  = now - 1.month
+  def lastYear()   = now - 1.year
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticInterval.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticInterval.scala
@@ -24,30 +24,30 @@ object StaticInterval extends StaticInterval
 trait StaticInterval {
   def parse(str: String) = Interval.parse(str)
 
-  def thisSecond = StaticDateTime.now.second.interval
-  def thisMinute = StaticDateTime.now.minute.interval
-  def thisHour   = StaticDateTime.now.hour.interval
-  def thisDay    = StaticDateTime.now.day.interval
-  def today      = StaticDateTime.now.day.interval
-  def thisWeek   = StaticDateTime.now.week.interval
-  def thisMonth  = StaticDateTime.now.month.interval
-  def thisYear   = StaticDateTime.now.year.interval
+  def thisSecond() = StaticDateTime.now.second.interval
+  def thisMinute() = StaticDateTime.now.minute.interval
+  def thisHour()   = StaticDateTime.now.hour.interval
+  def thisDay()    = StaticDateTime.now.day.interval
+  def today()      = StaticDateTime.now.day.interval
+  def thisWeek()   = StaticDateTime.now.week.interval
+  def thisMonth()  = StaticDateTime.now.month.interval
+  def thisYear()   = StaticDateTime.now.year.interval
 
-  def nextSecond = StaticDateTime.nextSecond.second.interval
-  def nextMinute = StaticDateTime.nextMinute.minute.interval
-  def nextHour   = StaticDateTime.nextHour.hour.interval
-  def nextDay    = StaticDateTime.nextDay.day.interval
-  def tomorrow   = StaticDateTime.nextDay.day.interval
-  def nextWeek   = StaticDateTime.nextWeek.week.interval
-  def nextMonth  = StaticDateTime.nextMonth.month.interval
-  def nextYear   = StaticDateTime.nextYear.year.interval
+  def nextSecond() = StaticDateTime.nextSecond.second.interval
+  def nextMinute() = StaticDateTime.nextMinute.minute.interval
+  def nextHour()   = StaticDateTime.nextHour.hour.interval
+  def nextDay()    = StaticDateTime.nextDay.day.interval
+  def tomorrow()   = StaticDateTime.nextDay.day.interval
+  def nextWeek()   = StaticDateTime.nextWeek.week.interval
+  def nextMonth()  = StaticDateTime.nextMonth.month.interval
+  def nextYear()   = StaticDateTime.nextYear.year.interval
 
-  def lastSecond = StaticDateTime.lastSecond.second.interval
-  def lastMinute = StaticDateTime.lastMinute.minute.interval
-  def lastHour   = StaticDateTime.lastHour.hour.interval
-  def lastDay    = StaticDateTime.lastDay.day.interval
-  def yesterday  = StaticDateTime.lastDay.day.interval
-  def lastWeek   = StaticDateTime.lastWeek.week.interval
-  def lastMonth  = StaticDateTime.lastMonth.month.interval
-  def lastYear   = StaticDateTime.lastYear.year.interval
+  def lastSecond() = StaticDateTime.lastSecond.second.interval
+  def lastMinute() = StaticDateTime.lastMinute.minute.interval
+  def lastHour()   = StaticDateTime.lastHour.hour.interval
+  def lastDay()    = StaticDateTime.lastDay.day.interval
+  def yesterday()  = StaticDateTime.lastDay.day.interval
+  def lastWeek()   = StaticDateTime.lastWeek.week.interval
+  def lastMonth()  = StaticDateTime.lastMonth.month.interval
+  def lastYear()   = StaticDateTime.lastYear.year.interval
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticLocalDate.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticLocalDate.scala
@@ -32,22 +32,22 @@ trait StaticLocalDate {
   def fromDateFields(date: Date) =
     LocalDate.fromDateFields(date)
   
-  def now        = new LocalDate
+  def now()        = new LocalDate
   def now(zone: DateTimeZone) = LocalDate.now(zone)
   def now(chronology: Chronology) = LocalDate.now(chronology)
-  def today      = new LocalDate
+  def today()      = new LocalDate
   def parse(str: String) = LocalDate.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = LocalDate.parse(str, formatter)
 
-  def nextDay    = now + 1.day
-  def tomorrow   = now + 1.day
-  def nextWeek   = now + 1.week
-  def nextMonth  = now + 1.month
-  def nextYear   = now + 1.year
+  def nextDay()    = now + 1.day
+  def tomorrow()   = now + 1.day
+  def nextWeek()   = now + 1.week
+  def nextMonth()  = now + 1.month
+  def nextYear()   = now + 1.year
 
-  def lastDay    = now - 1.day
-  def yesterday  = now - 1.day
-  def lastWeek   = now - 1.week
-  def lastMonth  = now - 1.month
-  def lastYear   = now - 1.year
+  def lastDay()    = now - 1.day
+  def yesterday()  = now - 1.day
+  def lastWeek()   = now - 1.week
+  def lastMonth()  = now - 1.month
+  def lastYear()   = now - 1.year
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticLocalDateTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticLocalDateTime.scala
@@ -31,27 +31,27 @@ trait StaticLocalDateTime {
   def fromDateFields(date: Date) =
     LocalDateTime.fromDateFields(date)
 
-  def now        = new LocalDateTime
+  def now()        = new LocalDateTime
   def now(zone: DateTimeZone) = LocalDateTime.now(zone)
   def now(chronology: Chronology) = LocalDateTime.now(chronology)
   def parse(str: String) = LocalDateTime.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = LocalDateTime.parse(str, formatter)
 
-  def nextSecond = now + 1.second
-  def nextMinute = now + 1.minute
-  def nextHour   = now + 1.hour
-  def nextDay    = now + 1.day
-  def tomorrow   = now + 1.day
-  def nextWeek   = now + 1.week
-  def nextMonth  = now + 1.month
-  def nextYear   = now + 1.year
+  def nextSecond() = now + 1.second
+  def nextMinute() = now + 1.minute
+  def nextHour()   = now + 1.hour
+  def nextDay()    = now + 1.day
+  def tomorrow()   = now + 1.day
+  def nextWeek()   = now + 1.week
+  def nextMonth()  = now + 1.month
+  def nextYear()   = now + 1.year
 
-  def lastSecond = now - 1.second
-  def lastMinute = now - 1.minute
-  def lastHour   = now - 1.hour
-  def lastDay    = now - 1.day
-  def yesterday  = now - 1.day
-  def lastWeek   = now - 1.week
-  def lastMonth  = now - 1.month
-  def lastYear   = now - 1.year
+  def lastSecond() = now - 1.second
+  def lastMinute() = now - 1.minute
+  def lastHour()   = now - 1.hour
+  def lastDay()    = now - 1.day
+  def yesterday()  = now - 1.day
+  def lastWeek()   = now - 1.week
+  def lastMonth()  = now - 1.month
+  def lastYear()   = now - 1.year
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticLocalTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticLocalTime.scala
@@ -39,17 +39,17 @@ trait StaticLocalTime {
   def fromMillisOfDay(millis: Long, chrono: Chronology) =
     LocalTime.fromMillisOfDay(millis, chrono)
 
-  def now        = new LocalTime
+  def now()        = new LocalTime
   def now(zone: DateTimeZone) = LocalTime.now(zone)
   def now(chronology: Chronology) = LocalTime.now(chronology)
   def parse(str: String) = LocalTime.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = LocalTime.parse(str, formatter)
 
-  def nextSecond = now + 1.second
-  def nextMinute = now + 1.minute
-  def nextHour   = now + 1.hour
+  def nextSecond() = now + 1.second
+  def nextMinute() = now + 1.minute
+  def nextHour()   = now + 1.hour
 
-  def lastSecond = now - 1.second
-  def lastMinute = now - 1.minute
-  def lastHour   = now - 1.hour
+  def lastSecond() = now - 1.second
+  def lastMinute() = now - 1.minute
+  def lastHour()   = now - 1.hour
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticMonthDay.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticMonthDay.scala
@@ -27,7 +27,7 @@ trait StaticMonthDay {
 
   def fromCalendarFields(calendar: Calendar) = MonthDay.fromCalendarFields(calendar)
   def fromDateFields(date: Date) = MonthDay.fromDateFields(date)
-  def now = MonthDay.now()
+  def now() = MonthDay.now()
   def now(chronology: Chronology) = MonthDay.now(chronology)
   def now(zone: DateTimeZone) = MonthDay.now(zone)
   def parse(str: String) = MonthDay.parse(str)

--- a/src/main/scala/com/github/nscala_time/time/StaticYearMonth.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticYearMonth.scala
@@ -27,7 +27,7 @@ trait StaticYearMonth {
 
   def fromCalendarFields(calendar: Calendar) = YearMonth.fromCalendarFields(calendar)
   def fromDateFields(date: Date) = YearMonth.fromDateFields(date)
-  def now = YearMonth.now()
+  def now() = YearMonth.now()
   def now(chronology: Chronology) = YearMonth.now(chronology)
   def now(zone: DateTimeZone) = YearMonth.now(zone)
   def parse(str: String) = YearMonth.parse(str)


### PR DESCRIPTION
There are some methods depend on the current time, e.g. `DateTime.now`.
These methods are not a pure function, so in accordance with the Scala Style Guide, I want to call them with parentheses: `DateTime.now()`.
However these methods are declared without parentheses, e.g. `def now = new DateTime`, it forces us to call them without parentheses.

In this PR, I declared above methods with parentheses.

Thanks!