### PR TITLE
Added "in" method for RichReadableInstant

### DIFF
--- a/src/main/scala/com/github/nscala_time/time/RichReadableInstant.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichReadableInstant.scala
@@ -32,6 +32,8 @@ class RichReadableInstant(val underlying: ReadableInstant) extends AnyVal with O
 
   def to(other: ReadableInstant): Interval = new Interval(underlying, other)
 
+  def in(interval: Interval) = interval.contains(underlying)
+
   def instant: Instant = underlying.toInstant
 
 }


### PR DESCRIPTION
Hello!

I suggest to consider this change to make improvement according to issue https://github.com/nscala-time/nscala-time/issues/110

This makes possible to create constructions like one below
```
DateTime.lastHour in (DateTime.lastDay to DateTime.now) // evaluates to 'true'
DateTime.nextYear in (DateTime.lastMonth to DateTime.nextWeek) // evaluates to 'false'
```

It can be useful to create simple and very clean one-liner checks that one Instant is in some bounds.