### PR TITLE
implicit conversion from DurationBuilder to FiniteDuration

### DIFF
--- a/src/main/scala/com/github/nscala_time/time/Implicits.scala
+++ b/src/main/scala/com/github/nscala_time/time/Implicits.scala
@@ -22,7 +22,7 @@ import org.joda.time._
 import base.{BaseSingleFieldPeriod, AbstractDateTime, AbstractInstant, AbstractPartial}
 import org.joda.time.format.DateTimeFormatter
 import org.joda.time.field.AbstractReadableInstantFieldProperty
-import scala.concurrent.duration.{ Duration => SDuration }
+import scala.concurrent.duration.{ Duration => SDuration, MILLISECONDS, FiniteDuration }
 
 object Implicits extends Implicits
 object BuilderImplicits extends BuilderImplicits
@@ -55,6 +55,7 @@ trait DateImplicits {
 
 trait ScalaDurationImplicits {
   implicit def richSDuration(d: SDuration): RichSDuration = new com.github.nscala_time.time.RichSDuration(d)
+  implicit def durationBuilderToScalaDuration(d: DurationBuilder): FiniteDuration = FiniteDuration(d.millis, MILLISECONDS)
 }
 
 trait OrderingImplicits extends LowPriorityOrderingImplicits {


### PR DESCRIPTION
convenient for something like 
```scala
// already using this library
import com.github.nscala_time.time.Imports._
// assuming there's some method that takes scala.concurrent.duration.FiniteDuration
//finiteDurationFunction(finiteDuration: scala.concurrent.duration.FiniteDuration)
finiteDurationFunction(10.millis)
```