### PR TITLE
Related changes to nscala-time:

### DIFF
--- a/src/main/scala/com/github/nscala_time/time/DurationBuilder.scala
+++ b/src/main/scala/com/github/nscala_time/time/DurationBuilder.scala
@@ -19,8 +19,7 @@ package com.github.nscala_time.time
 import org.joda.time._
 
 object DurationBuilder {
-  def apply(underlying: Period): DurationBuilder =
-    new DurationBuilder(underlying)
+  def apply(underlying: Period): DurationBuilder = new DurationBuilder(underlying)
 }
 
 // Duration Builder
@@ -28,42 +27,26 @@ class DurationBuilder(val underlying: Period) extends AnyVal {
   // DurationBuilder + DurationBuilder = DurationBuilder
   // This is the only operation that can maintain a DurationBuilder
   // Everything else kicks us out to DateTime, Duration, or Period
-  def +(that: DurationBuilder): DurationBuilder =
-    DurationBuilder(this.underlying.plus(that.underlying))
-  def -(that: DurationBuilder): DurationBuilder =
-    DurationBuilder(this.underlying.minus(that.underlying))
+  def +(that: DurationBuilder): DurationBuilder = DurationBuilder(this.underlying.plus(that.underlying))
+  def -(that: DurationBuilder): DurationBuilder = DurationBuilder(this.underlying.minus(that.underlying))
 
-  def ago(): DateTime =
-    StaticDateTime.now.minus(underlying)
-  def later(): DateTime =
-    StaticDateTime.now.plus(underlying)
-  def from(dt: DateTime): DateTime =
-    dt.plus(underlying)
-  def before(dt: DateTime): DateTime =
-    dt.minus(underlying)
+  def ago(): DateTime                = StaticDateTime.now().minus(underlying)
+  def later(): DateTime              = StaticDateTime.now().plus(underlying)
+  def from(dt: DateTime): DateTime   = dt.plus(underlying)
+  def before(dt: DateTime): DateTime = dt.minus(underlying)
 
-  def standardDuration: Duration =
-    underlying.toStandardDuration
-  def toDuration: Duration =
-    underlying.toStandardDuration
-  def toPeriod: Period =
-    underlying
+  def standardDuration: Duration = underlying.toStandardDuration
+  def toDuration: Duration       = underlying.toStandardDuration
+  def toPeriod: Period           = underlying
 
-  def -(period: ReadablePeriod): Period =
-    underlying.minus(period)
-  def +(period: ReadablePeriod): Period =
-    underlying.plus(period)
+  def -(period: ReadablePeriod): Period = underlying.minus(period)
+  def +(period: ReadablePeriod): Period = underlying.plus(period)
 
-  def millis: Long =
-    underlying.toStandardDuration.getMillis
-  def seconds: Long =
-    underlying.toStandardDuration.getStandardSeconds
-  def -(amount: Long): Duration =
-    underlying.toStandardDuration.minus(amount)
-  def -(amount: ReadableDuration): Duration =
-    underlying.toStandardDuration.minus(amount)
-  def +(amount: Long): Duration =
-    underlying.toStandardDuration.plus(amount)
-  def +(amount: ReadableDuration): Duration =
-    underlying.toStandardDuration.plus(amount)
+  def millis: Long  = underlying.toStandardDuration.getMillis
+  def seconds: Long = underlying.toStandardDuration.getStandardSeconds
+
+  def -(amount: Long): Duration             = underlying.toStandardDuration.minus(amount)
+  def -(amount: ReadableDuration): Duration = underlying.toStandardDuration.minus(amount)
+  def +(amount: Long): Duration             = underlying.toStandardDuration.plus(amount)
+  def +(amount: ReadableDuration): Duration = underlying.toStandardDuration.plus(amount)
 }

--- a/src/main/scala/com/github/nscala_time/time/Implicits.scala
+++ b/src/main/scala/com/github/nscala_time/time/Implicits.scala
@@ -31,17 +31,16 @@ object StringImplicits extends StringImplicits
 object OrderingImplicits extends OrderingImplicits
 object JodaImplicits extends JodaImplicits
 
-trait Implicits extends BuilderImplicits with IntImplicits with StringImplicits with DateImplicits with ScalaDurationImplicits with OrderingImplicits with JodaImplicits
+trait Implicits extends BuilderImplicits with IntImplicits
+  with StringImplicits with DateImplicits with ScalaDurationImplicits with OrderingImplicits with JodaImplicits
 
 trait BuilderImplicits {
-  implicit def forcePeriod(builder: DurationBuilder): Period =
-    builder.underlying
-  implicit def forceDuration(builder: DurationBuilder): Duration =
-    builder.underlying.toStandardDuration
+  implicit def forcePeriod(builder: DurationBuilder): Period     = builder.underlying
+  implicit def forceDuration(builder: DurationBuilder): Duration = builder.underlying.toStandardDuration
 }
 
 trait IntImplicits {
-  implicit def richInt(n: Int): RichInt = new com.github.nscala_time.time.RichInt(n)
+  implicit def richInt(n: Int): RichInt    = new com.github.nscala_time.time.RichInt(n)
   implicit def richLong(n: Long): RichLong = new com.github.nscala_time.time.RichLong(n)
 }
 
@@ -58,11 +57,11 @@ trait ScalaDurationImplicits {
 }
 
 trait OrderingImplicits extends LowPriorityOrderingImplicits {
-  implicit val DateTimeOrdering: Ordering[DateTime] = ReadableInstantOrdering[DateTime]
-  implicit val LocalDateOrdering: Ordering[LocalDate] = ReadablePartialOrdering[LocalDate]
-  implicit val LocalTimeOrdering: Ordering[LocalTime] = ReadablePartialOrdering[LocalTime]
+  implicit val DateTimeOrdering: Ordering[DateTime]           = ReadableInstantOrdering[DateTime]
+  implicit val LocalDateOrdering: Ordering[LocalDate]         = ReadablePartialOrdering[LocalDate]
+  implicit val LocalTimeOrdering: Ordering[LocalTime]         = ReadablePartialOrdering[LocalTime]
   implicit val LocalDateTimeOrdering: Ordering[LocalDateTime] = ReadablePartialOrdering[LocalDateTime]
-  implicit val DurationOrdering: Ordering[Duration] = ReadableDurationOrdering[Duration]
+  implicit val DurationOrdering: Ordering[Duration]           = ReadableDurationOrdering[Duration]
 }
 
 trait LowPriorityOrderingImplicits {
@@ -75,30 +74,42 @@ trait LowPriorityOrderingImplicits {
 
 trait JodaImplicits {
   implicit def richAbstractDateTime(dt: AbstractDateTime): RichAbstractDateTime = new RichAbstractDateTime(dt)
-  implicit def richAbstractInstant(in: AbstractInstant): RichAbstractInstant = new RichAbstractInstant(in)
-  implicit def richAbstractPartial(pt: AbstractPartial): RichAbstractPartial = new RichAbstractPartial(pt)
-  implicit def richAbstractReadableInstantFieldProperty(pty: AbstractReadableInstantFieldProperty): RichAbstractReadableInstantFieldProperty = new RichAbstractReadableInstantFieldProperty(pty)
+  implicit def richAbstractInstant(in: AbstractInstant): RichAbstractInstant    = new RichAbstractInstant(in)
+  implicit def richAbstractPartial(pt: AbstractPartial): RichAbstractPartial    = new RichAbstractPartial(pt)
+
+  private[this] type ARIFP  = AbstractReadableInstantFieldProperty
+  private[this] type RARIFP = RichAbstractReadableInstantFieldProperty
+  implicit def richAbstractReadableInstantFieldProperty(pty: ARIFP): RARIFP = new RARIFP(pty)
+
   implicit def richChronology(ch: Chronology): RichChronology = new RichChronology(ch)
-  implicit def richDateTime(dt: DateTime): RichDateTime = new RichDateTime(dt)
+
+  implicit def richDateTime(dateTime: DateTime): RichDateTime                       = new RichDateTime(dateTime)
   implicit def richDateTimeFormatter(fmt: DateTimeFormatter): RichDateTimeFormatter = new RichDateTimeFormatter(fmt)
-  implicit def richDateTimeProperty(pty: DateTime.Property): RichDateTimeProperty = new RichDateTimeProperty(pty)
-  implicit def richDateTimeZone(zone: DateTimeZone): RichDateTimeZone = new RichDateTimeZone(zone)
+  implicit def richDateTimeProperty(pty: DateTime.Property): RichDateTimeProperty   = new RichDateTimeProperty(pty)
+  implicit def richDateTimeZone(zone: DateTimeZone): RichDateTimeZone               = new RichDateTimeZone(zone)
+
   implicit def richDuration(dur: Duration): RichDuration = new RichDuration(dur)
-  implicit def richInstant(in: Instant): RichInstant = new RichInstant(in)
-  implicit def richInterval(in: Interval): RichInterval = new RichInterval(in)
-  implicit def richLocalDate(ld: LocalDate): RichLocalDate = new RichLocalDate(ld)
-  implicit def richLocalDateProperty(pty: LocalDate.Property): RichLocalDateProperty = new RichLocalDateProperty(pty)
-  implicit def richLocalDateTime(dt: LocalDateTime): RichLocalDateTime = new RichLocalDateTime(dt)
-  implicit def richLocalDateTimeProperty(pty: LocalDateTime.Property): RichLocalDateTimeProperty = new RichLocalDateTimeProperty(pty)
-  implicit def richLocalTime(lt: LocalTime): RichLocalTime = new RichLocalTime(lt)
-  implicit def richLocalTimeProperty(pty: LocalTime.Property): RichLocalTimeProperty = new RichLocalTimeProperty(pty)
-  implicit def richPartial(pt: Partial): RichPartial = new RichPartial(pt)
+  implicit def richInstant(in: Instant): RichInstant     = new RichInstant(in)
+  implicit def richInterval(in: Interval): RichInterval  = new RichInterval(in)
+
+  private[this] type DateTimeProperty = LocalDateTime.Property
+  private[this] type DateProperty     = LocalDate.Property
+  private[this] type TimeProperty     = LocalTime.Property
+  implicit def richLocalDate(ld: LocalDate): RichLocalDate                           = new RichLocalDate(ld)
+  implicit def richLocalDateProperty(pty: DateProperty): RichLocalDateProperty       = new RichLocalDateProperty(pty)
+  implicit def richLocalDateTime(dt: LocalDateTime): RichLocalDateTime               = new RichLocalDateTime(dt)
+  implicit def richLocalDateTimeProperty(pty: DateTimeProperty): RichLocalDateTimeProperty = new RichLocalDateTimeProperty(pty)
+  implicit def richLocalTime(lt: LocalTime): RichLocalTime                           = new RichLocalTime(lt)
+  implicit def richLocalTimeProperty(pty: TimeProperty): RichLocalTimeProperty       = new RichLocalTimeProperty(pty)
+
+  implicit def richPartial(pt: Partial): RichPartial                           = new RichPartial(pt)
   implicit def richPartialProperty(pty: Partial.Property): RichPartialProperty = new RichPartialProperty(pty)
-  implicit def richPeriod(per: Period): RichPeriod = new RichPeriod(per)
-  implicit def richReadableDateTime(dt: ReadableDateTime): RichReadableDateTime = new RichReadableDateTime(dt)
+  implicit def richPeriod(per: Period): RichPeriod                             = new RichPeriod(per)
+
+  implicit def richReadableDateTime(dt: ReadableDateTime): RichReadableDateTime  = new RichReadableDateTime(dt)
   implicit def richReadableDuration(dur: ReadableDuration): RichReadableDuration = new RichReadableDuration(dur)
-  implicit def richReadableInstant(in: ReadableInstant): RichReadableInstant = new RichReadableInstant(in)
-  implicit def richReadableInterval(in: ReadableInterval): RichReadableInterval = new RichReadableInterval(in)
-  implicit def richReadablePartial(rp: ReadablePartial): RichReadablePartial = new RichReadablePartial(rp)
-  implicit def richReadablePeriod(per: ReadablePeriod): RichReadablePeriod = new RichReadablePeriod(per)
+  implicit def richReadableInstant(in: ReadableInstant): RichReadableInstant     = new RichReadableInstant(in)
+  implicit def richReadableInterval(in: ReadableInterval): RichReadableInterval  = new RichReadableInterval(in)
+  implicit def richReadablePartial(rp: ReadablePartial): RichReadablePartial     = new RichReadablePartial(rp)
+  implicit def richReadablePeriod(per: ReadablePeriod): RichReadablePeriod       = new RichReadablePeriod(per)
 }

--- a/src/main/scala/com/github/nscala_time/time/RichAbstractDateTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichAbstractDateTime.scala
@@ -20,8 +20,7 @@ import java.util.{Locale, Calendar}
 import org.joda.time.base.AbstractDateTime
 import com.github.nscala_time.PimpedType
 
-class RichAbstractDateTime(val underlying: AbstractDateTime) extends AnyVal
-  with PimpedType[AbstractDateTime] {
+private[time] class RichAbstractDateTime(val underlying: AbstractDateTime) extends AnyVal with PimpedType[AbstractDateTime] {
 
   def calendar(locale: Locale): Calendar = underlying.toCalendar(locale)
 

--- a/src/main/scala/com/github/nscala_time/time/RichAbstractInstant.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichAbstractInstant.scala
@@ -21,27 +21,19 @@ import org.joda.time._
 import org.joda.time.base.AbstractInstant
 import com.github.nscala_time.PimpedType
 
-class RichAbstractInstant(val underlying: AbstractInstant) extends AnyVal
-  with PimpedType[AbstractInstant] {
+private[time] class RichAbstractInstant(val underlying: AbstractInstant) extends AnyVal with PimpedType[AbstractInstant] {
 
-  def date: Date = underlying.toDate
-
-  def dateTime: DateTime = underlying.toDateTime
-
+  def date: Date                                 = underlying.toDate
+  def dateTime: DateTime                         = underlying.toDateTime
   def dateTime(chronology: Chronology): DateTime = underlying.toDateTime(chronology)
-
-  def dateTime(zone: DateTimeZone): DateTime = underlying.toDateTime(zone)
-
-  def dateTimeISO: DateTime = underlying.toDateTimeISO
+  def dateTime(zone: DateTimeZone): DateTime     = underlying.toDateTime(zone)
+  def dateTimeISO: DateTime                      = underlying.toDateTimeISO
 
   def instant: Instant = underlying.toInstant
 
-  def mutableDateTime: MutableDateTime = underlying.toMutableDateTime
-
+  def mutableDateTime: MutableDateTime                         = underlying.toMutableDateTime
   def mutableDateTime(chronology: Chronology): MutableDateTime = underlying.toMutableDateTime(chronology)
-
-  def mutableDateTime(zone: DateTimeZone): MutableDateTime = underlying.toMutableDateTime(zone)
-
-  def mutableDateTimeISO: MutableDateTime = underlying.toMutableDateTimeISO
+  def mutableDateTime(zone: DateTimeZone): MutableDateTime     = underlying.toMutableDateTime(zone)
+  def mutableDateTimeISO: MutableDateTime                      = underlying.toMutableDateTimeISO
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichAbstractPartial.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichAbstractPartial.scala
@@ -19,12 +19,11 @@ package com.github.nscala_time.time
 import org.joda.time.base.AbstractPartial
 import com.github.nscala_time.PimpedType
 
-class RichAbstractPartial(val underlying: AbstractPartial) extends AnyVal with Ordered[AbstractPartial] with
-  PimpedType[AbstractPartial] {
-  def fields = underlying.getFields
+private[time] class RichAbstractPartial(val underlying: AbstractPartial) extends AnyVal
+  with Ordered[AbstractPartial] with PimpedType[AbstractPartial] {
+  def fields     = underlying.getFields
   def fieldTypes = underlying.getFieldTypes
-  def values = underlying.getValues
+  def values     = underlying.getValues
 
-  override def compare(that: AbstractPartial): Int =
-    underlying.compareTo(that)
+  override def compare(that: AbstractPartial): Int = underlying.compareTo(that)
 }

--- a/src/main/scala/com/github/nscala_time/time/RichAbstractReadableInstantFieldProperty.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichAbstractReadableInstantFieldProperty.scala
@@ -21,52 +21,38 @@ import org.joda.time._
 import org.joda.time.field.AbstractReadableInstantFieldProperty
 import com.github.nscala_time.PimpedType
 
-class RichAbstractReadableInstantFieldProperty(val underlying: AbstractReadableInstantFieldProperty) extends AnyVal
+private[time] class RichAbstractReadableInstantFieldProperty(val underlying: AbstractReadableInstantFieldProperty) extends AnyVal
   with PimpedType[AbstractReadableInstantFieldProperty] {
 
-  def shortText: String = underlying.getAsShortText
-
-  def asShortText: String = underlying.getAsShortText
-
+  def shortText: String                 = underlying.getAsShortText
   def shortText(locale: Locale): String = underlying.getAsShortText(locale)
 
+  def asShortText: String                 = underlying.getAsShortText
   def asShortText(locale: Locale): String = underlying.getAsShortText(locale)
+  def asString: String                    = underlying.getAsString
 
-  def asString: String = underlying.getAsString
-
-  def text: String = underlying.getAsText
-
-  def asText: String = underlying.getAsText
-
+  def text: String                 = underlying.getAsText
   def text(locale: Locale): String = underlying.getAsText(locale)
 
+  def asText: String                 = underlying.getAsText
   def asText(locale: Locale): String = underlying.getAsText(locale)
 
   def durationField: DurationField = underlying.getDurationField
-
-  def field: DateTimeField = underlying.getField
-
+  def field: DateTimeField         = underlying.getField
   def fieldType: DateTimeFieldType = underlying.getFieldType
 
-  def leapAmount: Int = underlying.getLeapAmount
-
+  def leapAmount: Int                  = underlying.getLeapAmount
   def leapDurationField: DurationField = underlying.getLeapDurationField
 
-  def maximumValue: Int = underlying.getMaximumValue
-
-  def maxValue: Int = underlying.getMaximumValue
-
+  def maximumValue: Int        = underlying.getMaximumValue
+  def maxValue: Int            = underlying.getMaximumValue
   def maximumValueOverall: Int = underlying.getMaximumValueOverall
+  def maxValueOverall: Int     = underlying.getMaximumValueOverall
 
-  def maxValueOverall: Int = underlying.getMaximumValueOverall
-
-  def minimumValue: Int = underlying.getMinimumValue
-
-  def minValue: Int = underlying.getMinimumValue
-
+  def minimumValue: Int        = underlying.getMinimumValue
+  def minValue: Int            = underlying.getMinimumValue
   def minimumValueOverall: Int = underlying.getMinimumValueOverall
-
-  def minValueOverall: Int = underlying.getMinimumValueOverall
+  def minValueOverall: Int     = underlying.getMinimumValueOverall
 
   def name: String = underlying.getName
 

--- a/src/main/scala/com/github/nscala_time/time/RichChronology.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichChronology.scala
@@ -19,9 +19,9 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichChronology(val underlying: Chronology) extends AnyVal with PimpedType[Chronology] {
+private[time] class RichChronology(val underlying: Chronology) extends AnyVal with PimpedType[Chronology] {
 
   def zone: Option[DateTimeZone] = nullCheck(underlying.getZone)
 
-  private def nullCheck[T <: AnyRef](x: T): Option[T] = if (x == null) None else Some(x)
+  private def nullCheck[T <: AnyRef](x: T): Option[T] = Option(x)
 }

--- a/src/main/scala/com/github/nscala_time/time/RichDate.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichDate.scala
@@ -4,12 +4,10 @@ import java.util.Date
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichDate(val underlying: Date) extends AnyVal with PimpedType[Date] {
+private[time] class RichDate(val underlying: Date) extends AnyVal with PimpedType[Date] {
 
   def toLocalDateTime: LocalDateTime = StaticLocalDateTime.fromDateFields(underlying)
-
-  def toLocalDate: LocalDate = StaticLocalDate.fromDateFields(underlying)
-
-  def toLocalTime: LocalTime = StaticLocalTime.fromDateFields(underlying)
+  def toLocalDate: LocalDate         = StaticLocalDate.fromDateFields(underlying)
+  def toLocalTime: LocalTime         = StaticLocalTime.fromDateFields(underlying)
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichDateTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichDateTime.scala
@@ -19,59 +19,36 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichDateTime(val underlying: DateTime) extends AnyVal with PimpedType[DateTime] {
-
-  def -(duration: Long): DateTime = underlying.minus(duration)
-
+private[time] class RichDateTime(val underlying: DateTime) extends AnyVal with PimpedType[DateTime] {
+  private[this] type Property = DateTime.Property
+  def -(duration: Long): DateTime             = underlying.minus(duration)
   def -(duration: ReadableDuration): DateTime = underlying.minus(duration)
+  def -(period: ReadablePeriod): DateTime     = underlying.minus(period)
+  def -(builder: DurationBuilder): DateTime   = underlying.minus(builder.underlying)
 
-  def -(period: ReadablePeriod): DateTime = underlying.minus(period)
-
-  def -(builder: DurationBuilder): DateTime = underlying.minus(builder.underlying)
-
-  def +(duration: Long): DateTime = underlying.plus(duration)
-
+  def +(duration: Long): DateTime             = underlying.plus(duration)
   def +(duration: ReadableDuration): DateTime = underlying.plus(duration)
+  def +(period: ReadablePeriod): DateTime     = underlying.plus(period)
+  def +(builder: DurationBuilder): DateTime   = underlying.plus(builder.underlying)
 
-  def +(period: ReadablePeriod): DateTime = underlying.plus(period)
+  def millis: Property  = underlying.millisOfSecond()
+  def second: Property  = underlying.secondOfMinute
+  def minute: Property  = underlying.minuteOfHour
+  def hour: Property    = underlying.hourOfDay
+  def day: Property     = underlying.dayOfMonth
+  def week: Property    = underlying.weekOfWeekyear
+  def month: Property   = underlying.monthOfYear
+  def year: Property    = underlying.year
+  def century: Property = underlying.centuryOfEra
+  def era: Property     = underlying.era
 
-  def +(builder: DurationBuilder): DateTime = underlying.plus(builder.underlying)
-
-  def millis: DateTime.Property = underlying.millisOfSecond()
-
-  def second: DateTime.Property = underlying.secondOfMinute
-
-  def minute: DateTime.Property = underlying.minuteOfHour
-
-  def hour: DateTime.Property = underlying.hourOfDay
-
-  def day: DateTime.Property = underlying.dayOfMonth
-
-  def week: DateTime.Property = underlying.weekOfWeekyear
-
-  def month: DateTime.Property = underlying.monthOfYear
-
-  def year: DateTime.Property = underlying.year
-
-  def century: DateTime.Property = underlying.centuryOfEra
-
-  def era: DateTime.Property = underlying.era
-
-  def withSecond(second: Int) = underlying.withSecondOfMinute(second)
-
-  def withMinute(minute: Int) = underlying.withMinuteOfHour(minute)
-
-  def withHour(hour: Int) = underlying.withHourOfDay(hour)
-
-  def withDay(day: Int) = underlying.withDayOfMonth(day)
-
-  def withWeek(week: Int) = underlying.withWeekOfWeekyear(week)
-
-  def withMonth(month: Int) = underlying.withMonthOfYear(month)
-
-  def withYear(year: Int) = underlying.withYear(year)
-
+  def withSecond(second: Int)   = underlying.withSecondOfMinute(second)
+  def withMinute(minute: Int)   = underlying.withMinuteOfHour(minute)
+  def withHour(hour: Int)       = underlying.withHourOfDay(hour)
+  def withDay(day: Int)         = underlying.withDayOfMonth(day)
+  def withWeek(week: Int)       = underlying.withWeekOfWeekyear(week)
+  def withMonth(month: Int)     = underlying.withMonthOfYear(month)
+  def withYear(year: Int)       = underlying.withYear(year)
   def withCentury(century: Int) = underlying.withCenturyOfEra(century)
-
-  def withEra(era: Int) = underlying.withEra(era)
+  def withEra(era: Int)         = underlying.withEra(era)
 }

--- a/src/main/scala/com/github/nscala_time/time/RichDateTimeFormatter.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichDateTimeFormatter.scala
@@ -22,20 +22,14 @@ import org.joda.time.format.{DateTimeFormatter, DateTimeParser,
   DateTimePrinter}
 import com.github.nscala_time.PimpedType
 
-class RichDateTimeFormatter(val underlying: DateTimeFormatter) extends AnyVal
-  with PimpedType[DateTimeFormatter] {
+private[time] class RichDateTimeFormatter(val underlying: DateTimeFormatter) extends AnyVal with PimpedType[DateTimeFormatter] {
 
-  def chronology: Chronology = underlying.getChronology
-
-  def locale: Locale = underlying.getLocale
-
-  def parser: DateTimeParser = underlying.getParser
-
-  def pivotYear: Int = underlying.getPivotYear.intValue
-
+  def chronology: Chronology   = underlying.getChronology
+  def locale: Locale           = underlying.getLocale
+  def parser: DateTimeParser   = underlying.getParser
+  def pivotYear: Int           = underlying.getPivotYear.intValue
   def printer: DateTimePrinter = underlying.getPrinter
-
-  def zone: DateTimeZone = underlying.getZone
+  def zone: DateTimeZone       = underlying.getZone
 
   def parseOption(text: String): Option[DateTime] =
     try {

--- a/src/main/scala/com/github/nscala_time/time/RichDateTimeProperty.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichDateTimeProperty.scala
@@ -20,24 +20,18 @@ import java.util.Locale
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichDateTimeProperty(val underlying: DateTime.Property) extends AnyVal with PimpedType[DateTime.Property] {
+private[time] class RichDateTimeProperty(val underlying: DateTime.Property) extends AnyVal with PimpedType[DateTime.Property] {
 
   def dateTime: DateTime = underlying.getDateTime
 
-  def roundFloor: DateTime = underlying.roundFloorCopy
-
+  def roundFloor: DateTime   = underlying.roundFloorCopy
   def roundCeiling: DateTime = underlying.roundCeilingCopy
+  def roundDown: DateTime    = underlying.roundFloorCopy
+  def roundUp: DateTime      = underlying.roundCeilingCopy
+  def round: DateTime        = underlying.roundHalfEvenCopy
 
-  def roundDown: DateTime = underlying.roundFloorCopy
-
-  def roundUp: DateTime = underlying.roundCeilingCopy
-
-  def round: DateTime = underlying.roundHalfEvenCopy
-
-  def apply(value: Int): DateTime = underlying.setCopy(value)
-
-  def apply(text: String): DateTime = underlying.setCopy(text)
-
+  def apply(value: Int): DateTime                   = underlying.setCopy(value)
+  def apply(text: String): DateTime                 = underlying.setCopy(text)
   def apply(text: String, locale: Locale): DateTime = underlying.setCopy(text, locale)
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichDateTimeZone.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichDateTimeZone.scala
@@ -19,7 +19,7 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichDateTimeZone(val underlying: DateTimeZone) extends AnyVal with PimpedType[DateTimeZone] {
+private[time] class RichDateTimeZone(val underlying: DateTimeZone) extends AnyVal with PimpedType[DateTimeZone] {
 
   def id: String = underlying.getID
 

--- a/src/main/scala/com/github/nscala_time/time/RichDuration.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichDuration.scala
@@ -20,31 +20,22 @@ import org.joda.time._
 import com.github.nscala_time.PimpedType
 import scala.concurrent.duration.{ MILLISECONDS , FiniteDuration }
 
-class RichDuration(val underlying: Duration) extends AnyVal with PimpedType[Duration] {
+private[time] class RichDuration(val underlying: Duration) extends AnyVal with PimpedType[Duration] {
 
-  def days: Long = underlying.getStandardDays
-
-  def hours: Long = underlying.getStandardHours
-
-  def millis: Long = underlying.getMillis
-
+  def days: Long    = underlying.getStandardDays
+  def hours: Long   = underlying.getStandardHours
+  def millis: Long  = underlying.getMillis
   def minutes: Long = underlying.getStandardMinutes
-
   def seconds: Long = underlying.getStandardSeconds
 
   def unary_- : Duration = underlying.negated
 
-  def -(amount: Long): Duration = underlying.minus(amount)
-
+  def -(amount: Long): Duration             = underlying.minus(amount)
   def -(amount: ReadableDuration): Duration = underlying.minus(amount)
-
-  def +(amount: Long): Duration = underlying.plus(amount)
-
+  def +(amount: Long): Duration             = underlying.plus(amount)
   def +(amount: ReadableDuration): Duration = underlying.plus(amount)
-
-  def /(divisor: Long): Duration = underlying.dividedBy(divisor)
-
-  def *(multiplicand: Long): Duration = underlying.multipliedBy(multiplicand)
+  def /(divisor: Long): Duration            = underlying.dividedBy(divisor)
+  def *(multiplicand: Long): Duration       = underlying.multipliedBy(multiplicand)
 
   def toScalaDuration: FiniteDuration = FiniteDuration(underlying.getMillis, MILLISECONDS)
 

--- a/src/main/scala/com/github/nscala_time/time/RichInstant.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichInstant.scala
@@ -19,14 +19,11 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichInstant(val underlying: Instant) extends AnyVal with PimpedType[Instant] {
+private[time] class RichInstant(val underlying: Instant) extends AnyVal with PimpedType[Instant] {
 
-  def -(duration: Long): Instant = underlying.minus(duration)
-
+  def -(duration: Long): Instant             = underlying.minus(duration)
   def -(duration: ReadableDuration): Instant = underlying.minus(duration)
-
-  def +(duration: Long): Instant = underlying.plus(duration)
-
+  def +(duration: Long): Instant             = underlying.plus(duration)
   def +(duration: ReadableDuration): Instant = underlying.plus(duration)
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichInt.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichInt.scala
@@ -19,16 +19,13 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichInt(val underlying: Int) extends AnyVal with PimpedType[Int] {
+private[time] class RichInt(val underlying: Int) extends AnyVal with PimpedType[Int] {
   // These units of time can build durations or periods.
   // At most we lose a leap second. (Unless someone adopts
   // leap minutes).
   def millis  = DurationBuilder(Period.millis(underlying))
-
   def seconds = DurationBuilder(Period.seconds(underlying))
-
   def minutes = DurationBuilder(Period.minutes(underlying))
-
   def hours   = DurationBuilder(Period.hours(underlying))
 
   // These units of time can only be periods. At this

--- a/src/main/scala/com/github/nscala_time/time/RichInterval.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichInterval.scala
@@ -5,7 +5,7 @@ import com.github.nscala_time.PimpedType
 import org.joda.time._
 import scala.collection.generic.CanBuildFrom
 
-class RichInterval(val underlying: Interval) extends AnyVal with PimpedType[Interval] {
+private[time] class RichInterval(val underlying: Interval) extends AnyVal with PimpedType[Interval] {
 
   /** Returns a collection containing every instance between the interval, `period` time apart.
     *

--- a/src/main/scala/com/github/nscala_time/time/RichLocalDate.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichLocalDate.scala
@@ -20,40 +20,27 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichLocalDate(val underlying: LocalDate) extends AnyVal with PimpedType[LocalDate] {
+private[time] class RichLocalDate(val underlying: LocalDate) extends AnyVal with PimpedType[LocalDate] {
+  private[this] type Property = LocalDate.Property
 
-  def -(period: ReadablePeriod): LocalDate = underlying.minus(period)
-
+  def -(period: ReadablePeriod): LocalDate   = underlying.minus(period)
   def -(builder: DurationBuilder): LocalDate = underlying.minus(builder.underlying)
-
-  def +(period: ReadablePeriod): LocalDate = underlying.plus(period)
-
+  def +(period: ReadablePeriod): LocalDate   = underlying.plus(period)
   def +(builder: DurationBuilder): LocalDate = underlying.plus(builder.underlying)
 
-  def day: LocalDate.Property = underlying.dayOfMonth
+  def day: Property     = underlying.dayOfMonth
+  def week: Property    = underlying.weekOfWeekyear
+  def month: Property   = underlying.monthOfYear
+  def year: Property    = underlying.year
+  def century: Property = underlying.centuryOfEra
+  def era: Property     = underlying.era
 
-  def week: LocalDate.Property = underlying.weekOfWeekyear
-
-  def month: LocalDate.Property = underlying.monthOfYear
-
-  def year: LocalDate.Property = underlying.year
-
-  def century: LocalDate.Property = underlying.centuryOfEra
-
-  def era: LocalDate.Property = underlying.era
-
-  def withDay(day: Int) = underlying.withDayOfMonth(day)
-
-  def withWeek(week: Int) = underlying.withWeekOfWeekyear(week)
-
-  def withMonth(month: Int) = underlying.withMonthOfYear(month)
-
-  def withYear(year: Int) = underlying.withYear(year)
-
+  def withDay(day: Int)         = underlying.withDayOfMonth(day)
+  def withWeek(week: Int)       = underlying.withWeekOfWeekyear(week)
+  def withMonth(month: Int)     = underlying.withMonthOfYear(month)
+  def withYear(year: Int)       = underlying.withYear(year)
   def withCentury(century: Int) = underlying.withCenturyOfEra(century)
-
-  def withEra(era: Int) = underlying.withEra(era)
-
-  def interval = underlying.toInterval
+  def withEra(era: Int)         = underlying.withEra(era)
+  def interval                  = underlying.toInterval
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichLocalDateProperty.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichLocalDateProperty.scala
@@ -20,23 +20,16 @@ import java.util.Locale
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichLocalDateProperty(val underlying: LocalDate.Property) extends AnyVal with PimpedType[LocalDate.Property] {
+private[time] class RichLocalDateProperty(val underlying: LocalDate.Property) extends AnyVal with PimpedType[LocalDate.Property] {
 
-  def localDate: LocalDate = underlying.getLocalDate
-
-  def roundFloor: LocalDate = underlying.roundFloorCopy
-
+  def localDate: LocalDate    = underlying.getLocalDate
+  def roundFloor: LocalDate   = underlying.roundFloorCopy
   def roundCeiling: LocalDate = underlying.roundCeilingCopy
+  def roundDown: LocalDate    = underlying.roundFloorCopy
+  def roundUp: LocalDate      = underlying.roundCeilingCopy
+  def round: LocalDate        = underlying.roundHalfEvenCopy
 
-  def roundDown: LocalDate = underlying.roundFloorCopy
-
-  def roundUp: LocalDate = underlying.roundCeilingCopy
-
-  def round: LocalDate = underlying.roundHalfEvenCopy
-
-  def apply(value: Int): LocalDate = underlying.setCopy(value)
-
-  def apply(text: String): LocalDate = underlying.setCopy(text)
-
+  def apply(value: Int): LocalDate                   = underlying.setCopy(value)
+  def apply(text: String): LocalDate                 = underlying.setCopy(text)
   def apply(text: String, locale: Locale): LocalDate = underlying.setCopy(text, locale)
 }

--- a/src/main/scala/com/github/nscala_time/time/RichLocalDateTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichLocalDateTime.scala
@@ -19,53 +19,34 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichLocalDateTime(val underlying: LocalDateTime) extends AnyVal with PimpedType[LocalDateTime] {
+private[time] class RichLocalDateTime(val underlying: LocalDateTime) extends AnyVal with PimpedType[LocalDateTime] {
+  private[this] type Property = LocalDateTime.Property
 
   def -(duration: ReadableDuration): LocalDateTime = underlying.minus(duration)
-
-  def -(period: ReadablePeriod): LocalDateTime = underlying.minus(period)
-
-  def -(builder: DurationBuilder): LocalDateTime = underlying.minus(builder.underlying)
+  def -(period: ReadablePeriod): LocalDateTime     = underlying.minus(period)
+  def -(builder: DurationBuilder): LocalDateTime   = underlying.minus(builder.underlying)
 
   def +(duration: ReadableDuration): LocalDateTime = underlying.plus(duration)
+  def +(period: ReadablePeriod): LocalDateTime     = underlying.plus(period)
+  def +(builder: DurationBuilder): LocalDateTime   = underlying.plus(builder.underlying)
 
-  def +(period: ReadablePeriod): LocalDateTime = underlying.plus(period)
+  def second: Property  = underlying.secondOfMinute
+  def minute: Property  = underlying.minuteOfHour
+  def hour: Property    = underlying.hourOfDay
+  def day: Property     = underlying.dayOfMonth
+  def week: Property    = underlying.weekOfWeekyear
+  def month: Property   = underlying.monthOfYear
+  def year: Property    = underlying.year
+  def century: Property = underlying.centuryOfEra
+  def era: Property     = underlying.era
 
-  def +(builder: DurationBuilder): LocalDateTime = underlying.plus(builder.underlying)
-
-  def second: LocalDateTime.Property = underlying.secondOfMinute
-
-  def minute: LocalDateTime.Property = underlying.minuteOfHour
-
-  def hour: LocalDateTime.Property = underlying.hourOfDay
-
-  def day: LocalDateTime.Property = underlying.dayOfMonth
-
-  def week: LocalDateTime.Property = underlying.weekOfWeekyear
-
-  def month: LocalDateTime.Property = underlying.monthOfYear
-
-  def year: LocalDateTime.Property = underlying.year
-
-  def century: LocalDateTime.Property = underlying.centuryOfEra
-
-  def era: LocalDateTime.Property = underlying.era
-
-  def withSecond(second: Int) = underlying.withSecondOfMinute(second)
-
-  def withMinute(minute: Int) = underlying.withMinuteOfHour(minute)
-
-  def withHour(hour: Int) = underlying.withHourOfDay(hour)
-
-  def withDay(day: Int) = underlying.withDayOfMonth(day)
-
-  def withWeek(week: Int) = underlying.withWeekOfWeekyear(week)
-
-  def withMonth(month: Int) = underlying.withMonthOfYear(month)
-
-  def withYear(year: Int) = underlying.withYear(year)
-
+  def withSecond(second: Int)   = underlying.withSecondOfMinute(second)
+  def withMinute(minute: Int)   = underlying.withMinuteOfHour(minute)
+  def withHour(hour: Int)       = underlying.withHourOfDay(hour)
+  def withDay(day: Int)         = underlying.withDayOfMonth(day)
+  def withWeek(week: Int)       = underlying.withWeekOfWeekyear(week)
+  def withMonth(month: Int)     = underlying.withMonthOfYear(month)
+  def withYear(year: Int)       = underlying.withYear(year)
   def withCentury(century: Int) = underlying.withCenturyOfEra(century)
-
-  def withEra(era: Int) = underlying.withEra(era)
+  def withEra(era: Int)         = underlying.withEra(era)
 }

--- a/src/main/scala/com/github/nscala_time/time/RichLocalDateTimeProperty.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichLocalDateTimeProperty.scala
@@ -20,24 +20,17 @@ import java.util.Locale
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichLocalDateTimeProperty(val underlying: LocalDateTime.Property) extends AnyVal
+private[time] class RichLocalDateTimeProperty(val underlying: LocalDateTime.Property) extends AnyVal
   with PimpedType[LocalDateTime.Property] {
 
   def localDateTime: LocalDateTime = underlying.getLocalDateTime
+  def roundFloor: LocalDateTime    = underlying.roundFloorCopy
+  def roundCeiling: LocalDateTime  = underlying.roundCeilingCopy
+  def roundDown: LocalDateTime     = underlying.roundFloorCopy
+  def roundUp: LocalDateTime       = underlying.roundCeilingCopy
+  def round: LocalDateTime         = underlying.roundHalfEvenCopy
 
-  def roundFloor: LocalDateTime = underlying.roundFloorCopy
-
-  def roundCeiling: LocalDateTime = underlying.roundCeilingCopy
-
-  def roundDown: LocalDateTime = underlying.roundFloorCopy
-
-  def roundUp: LocalDateTime = underlying.roundCeilingCopy
-
-  def round: LocalDateTime = underlying.roundHalfEvenCopy
-
-  def apply(value: Int): LocalDateTime = underlying.setCopy(value)
-
-  def apply(text: String): LocalDateTime = underlying.setCopy(text)
-
+  def apply(value: Int): LocalDateTime                   = underlying.setCopy(value)
+  def apply(text: String): LocalDateTime                 = underlying.setCopy(text)
   def apply(text: String, locale: Locale): LocalDateTime = underlying.setCopy(text, locale)
 }

--- a/src/main/scala/com/github/nscala_time/time/RichLocalTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichLocalTime.scala
@@ -19,25 +19,19 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichLocalTime(val underlying: LocalTime) extends AnyVal with PimpedType[LocalTime] {
+private[time] class RichLocalTime(val underlying: LocalTime) extends AnyVal with PimpedType[LocalTime] {
 
-  def -(period: ReadablePeriod): LocalTime = underlying.minus(period)
-
+  def -(period: ReadablePeriod): LocalTime   = underlying.minus(period)
   def -(builder: DurationBuilder): LocalTime = underlying.minus(builder.underlying)
 
-  def +(period: ReadablePeriod): LocalTime = underlying.plus(period)
-
+  def +(period: ReadablePeriod): LocalTime   = underlying.plus(period)
   def +(builder: DurationBuilder): LocalTime = underlying.plus(builder.underlying)
 
   def second: LocalTime.Property = underlying.secondOfMinute
-
   def minute: LocalTime.Property = underlying.minuteOfHour
-
-  def hour: LocalTime.Property = underlying.hourOfDay
+  def hour: LocalTime.Property   = underlying.hourOfDay
 
   def withSecond(second: Int) = underlying.withSecondOfMinute(second)
-
   def withMinute(minute: Int) = underlying.withMinuteOfHour(minute)
-
-  def withHour(hour: Int) = underlying.withHourOfDay(hour)
+  def withHour(hour: Int)     = underlying.withHourOfDay(hour)
 }

--- a/src/main/scala/com/github/nscala_time/time/RichLocalTimeProperty.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichLocalTimeProperty.scala
@@ -20,24 +20,18 @@ import java.util.Locale
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichLocalTimeProperty(val underlying: LocalTime.Property) extends AnyVal with PimpedType[LocalTime.Property] {
+private[time] class RichLocalTimeProperty(val underlying: LocalTime.Property) extends AnyVal with PimpedType[LocalTime.Property] {
 
   def localTime: LocalTime = underlying.getLocalTime
 
-  def roundFloor: LocalTime = underlying.roundFloorCopy
-
+  def roundFloor: LocalTime   = underlying.roundFloorCopy
   def roundCeiling: LocalTime = underlying.roundCeilingCopy
+  def roundDown: LocalTime    = underlying.roundFloorCopy
+  def roundUp: LocalTime      = underlying.roundCeilingCopy
+  def round: LocalTime        = underlying.roundHalfEvenCopy
 
-  def roundDown: LocalTime = underlying.roundFloorCopy
-
-  def roundUp: LocalTime = underlying.roundCeilingCopy
-
-  def round: LocalTime = underlying.roundHalfEvenCopy
-
-  def apply(value: Int): LocalTime = underlying.setCopy(value)
-
-  def apply(text: String): LocalTime = underlying.setCopy(text)
-
+  def apply(value: Int): LocalTime                   = underlying.setCopy(value)
+  def apply(text: String): LocalTime                 = underlying.setCopy(text)
   def apply(text: String, locale: Locale): LocalTime = underlying.setCopy(text, locale)
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichLong.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichLong.scala
@@ -19,16 +19,14 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichLong(val underlying: Long) extends AnyVal with PimpedType[Long] {
+private[time] class RichLong(val underlying: Long) extends AnyVal with PimpedType[Long] {
 
   def toDateTime = new DateTime(underlying)
-
   def toDuration = new Duration(underlying)
 
   def -(duration: Duration): Duration = toDuration.minus(duration)
 
   def +(duration: Duration): Duration = duration.plus(underlying)
-
   def *(duration: Duration): Duration = duration.multipliedBy(underlying)
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichPartial.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichPartial.scala
@@ -19,16 +19,14 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichPartial(val underlying: Partial) extends AnyVal with PimpedType[Partial] {
+private[time] class RichPartial(val underlying: Partial) extends AnyVal with PimpedType[Partial] {
 
   def formatter = underlying.getFormatter
 
-  def -(period: ReadablePeriod): Partial = underlying.minus(period)
-
+  def -(period: ReadablePeriod): Partial   = underlying.minus(period)
   def -(builder: DurationBuilder): Partial = underlying.minus(builder.underlying)
 
-  def +(period: ReadablePeriod): Partial = underlying.plus(period)
-
+  def +(period: ReadablePeriod): Partial   = underlying.plus(period)
   def +(builder: DurationBuilder): Partial = underlying.plus(builder.underlying)
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichPartialProperty.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichPartialProperty.scala
@@ -20,14 +20,12 @@ import java.util.Locale
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichPartialProperty(val underlying: Partial.Property) extends AnyVal with PimpedType[Partial.Property] {
+private[time] class RichPartialProperty(val underlying: Partial.Property) extends AnyVal with PimpedType[Partial.Property] {
 
   def partial: Partial = underlying.getPartial
 
-  def apply(value: Int): Partial = underlying.setCopy(value)
-
-  def apply(text: String): Partial = underlying.setCopy(text)
-
+  def apply(value: Int): Partial                   = underlying.setCopy(value)
+  def apply(text: String): Partial                 = underlying.setCopy(text)
   def apply(text: String, locale: Locale): Partial = underlying.setCopy(text, locale)
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichPeriod.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichPeriod.scala
@@ -19,38 +19,26 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichPeriod(val underlying: Period) extends AnyVal with PimpedType[Period] {
+private[time] class RichPeriod(val underlying: Period) extends AnyVal with PimpedType[Period] {
 
-  def days: Int = underlying.getDays
-
-  def hours: Int = underlying.getHours
-
-  def millis: Int = underlying.getMillis
-
+  def days: Int    = underlying.getDays
+  def hours: Int   = underlying.getHours
+  def millis: Int  = underlying.getMillis
   def minutes: Int = underlying.getMinutes
-
-  def months: Int = underlying.getMonths
-
+  def months: Int  = underlying.getMonths
   def seconds: Int = underlying.getSeconds
-
-  def weeks: Int = underlying.getWeeks
-
-  def years: Int = underlying.getYears
+  def weeks: Int   = underlying.getWeeks
+  def years: Int   = underlying.getYears
 
   def unary_- : Period = underlying.negated
 
   def -(period: ReadablePeriod): Period = underlying.minus(period)
-
   def +(period: ReadablePeriod): Period = underlying.plus(period)
+  def *(scalar: Int): Period            = underlying.multipliedBy(scalar)
 
-  def *(scalar: Int): Period = underlying.multipliedBy(scalar)
-
-  def ago(): DateTime = StaticDateTime.now.minus(underlying)
-
-  def later(): DateTime = StaticDateTime.now.plus(underlying)
-
-  def from(dt: DateTime): DateTime = dt.plus(underlying)
-
+  def ago(): DateTime                = StaticDateTime.now().minus(underlying)
+  def later(): DateTime              = StaticDateTime.now().plus(underlying)
+  def from(dt: DateTime): DateTime   = dt.plus(underlying)
   def before(dt: DateTime): DateTime = dt.minus(underlying)
 
   def standardDuration: Duration = underlying.toStandardDuration

--- a/src/main/scala/com/github/nscala_time/time/RichReadableDateTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichReadableDateTime.scala
@@ -19,27 +19,18 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichReadableDateTime(val underlying: ReadableDateTime) extends AnyVal
-  with PimpedType[ReadableDateTime] {
+private[time] class RichReadableDateTime(val underlying: ReadableDateTime) extends AnyVal with PimpedType[ReadableDateTime] {
 
-  def second: Int = underlying.getSecondOfMinute
+  def second: Int        = underlying.getSecondOfMinute
+  def minute: Int        = underlying.getMinuteOfHour
+  def hour: Int          = underlying.getHourOfDay
+  def day: Int           = underlying.getDayOfMonth
+  def week: Int          = underlying.getWeekOfWeekyear
+  def month: Int         = underlying.getMonthOfYear
+  def year: Int          = underlying.getYear
+  def century: Int       = underlying.getCenturyOfEra
 
-  def minute: Int = underlying.getMinuteOfHour
-
-  def hour: Int = underlying.getHourOfDay
-
-  def day: Int = underlying.getDayOfMonth
-
-  def week: Int = underlying.getWeekOfWeekyear
-
-  def month: Int = underlying.getMonthOfYear
-
-  def year: Int = underlying.getYear
-
-  def century: Int = underlying.getCenturyOfEra
-
-  def dateTime: DateTime = underlying.toDateTime
-
+  def dateTime: DateTime               = underlying.toDateTime
   def mutableDateTime: MutableDateTime = underlying.toMutableDateTime
 
 }

--- a/src/main/scala/com/github/nscala_time/time/RichReadableDuration.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichReadableDuration.scala
@@ -19,7 +19,8 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichReadableDuration(val underlying: ReadableDuration) extends AnyVal with Ordered[ReadableDuration]
+private[time] class RichReadableDuration(val underlying: ReadableDuration) extends AnyVal
+  with Ordered[ReadableDuration]
   with PimpedType[ReadableDuration] {
 
   def millis: Long = underlying.getMillis

--- a/src/main/scala/com/github/nscala_time/time/RichReadableInstant.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichReadableInstant.scala
@@ -19,7 +19,8 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichReadableInstant(val underlying: ReadableInstant) extends AnyVal with Ordered[ReadableInstant]
+private[time] class RichReadableInstant(val underlying: ReadableInstant) extends AnyVal
+  with Ordered[ReadableInstant]
   with PimpedType[ReadableInstant] {
 
   def chronology: Chronology = underlying.getChronology

--- a/src/main/scala/com/github/nscala_time/time/RichReadableInterval.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichReadableInterval.scala
@@ -19,7 +19,7 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichReadableInterval(val underlying: ReadableInterval) extends AnyVal
+private[time] class RichReadableInterval(val underlying: ReadableInterval) extends AnyVal
   with PimpedType[ReadableInterval] {
 
   def chronology: Chronology = underlying.getChronology

--- a/src/main/scala/com/github/nscala_time/time/RichReadablePartial.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichReadablePartial.scala
@@ -19,7 +19,7 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichReadablePartial(val underlying: ReadablePartial) extends AnyVal with PimpedType[ReadablePartial] {
+private[time] class RichReadablePartial(val underlying: ReadablePartial) extends AnyVal with PimpedType[ReadablePartial] {
 
   def chronology = underlying.getChronology
 

--- a/src/main/scala/com/github/nscala_time/time/RichReadablePeriod.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichReadablePeriod.scala
@@ -19,7 +19,7 @@ package com.github.nscala_time.time
 import org.joda.time._
 import com.github.nscala_time.PimpedType
 
-class RichReadablePeriod(val underlying: ReadablePeriod) extends AnyVal with PimpedType[ReadablePeriod] {
+private[time] class RichReadablePeriod(val underlying: ReadablePeriod) extends AnyVal with PimpedType[ReadablePeriod] {
 
   def periodType: PeriodType = underlying.getPeriodType
 

--- a/src/main/scala/com/github/nscala_time/time/RichSDuration.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichSDuration.scala
@@ -4,7 +4,7 @@ import org.joda.time._
 import com.github.nscala_time.PimpedType
 import scala.concurrent.duration.{ Duration => SDuration }
 
-class RichSDuration(val underlying: SDuration) extends AnyVal with PimpedType[SDuration] {
+private[time] class RichSDuration(val underlying: SDuration) extends AnyVal with PimpedType[SDuration] {
 
   def toJodaDuration: Duration = new Duration(underlying.toMillis)
 

--- a/src/main/scala/com/github/nscala_time/time/RichString.scala
+++ b/src/main/scala/com/github/nscala_time/time/RichString.scala
@@ -20,7 +20,7 @@ import org.joda.time._
 
 import org.joda.time.format.DateTimeFormat
 
-class RichString(val s: String) extends AnyVal {
+private[time] class RichString(val s: String) extends AnyVal {
   def toDateTime                        = new DateTime(s)
   def toInterval                        = new Interval(s)
   def toLocalDate                       = new LocalDate(s)

--- a/src/main/scala/com/github/nscala_time/time/StaticDateTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticDateTime.scala
@@ -20,32 +20,33 @@ import org.joda.time._
 import com.github.nscala_time.time.Implicits._
 import org.joda.time.format.DateTimeFormatter
 
-object StaticDateTime extends StaticDateTime
+private[time] object StaticDateTime extends StaticDateTime
 
-trait StaticDateTime {
+private[time] trait StaticDateTime {
   type Property = DateTime.Property
 
-  def now()        = new DateTime
-  def now(zone: DateTimeZone) = DateTime.now(zone)
+  def now()                       = new DateTime
+  def now(zone: DateTimeZone)     = DateTime.now(zone)
   def now(chronology: Chronology) = DateTime.now(chronology)
+
   def parse(str: String) = DateTime.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = DateTime.parse(str, formatter)
 
-  def nextSecond() = now + 1.second
-  def nextMinute() = now + 1.minute
-  def nextHour()   = now + 1.hour
-  def nextDay()    = now + 1.day
-  def tomorrow()   = now + 1.day
-  def nextWeek()   = now + 1.week
-  def nextMonth()  = now + 1.month
-  def nextYear()   = now + 1.year
+  def nextSecond() = now() + 1.second
+  def nextMinute() = now() + 1.minute
+  def nextHour()   = now() + 1.hour
+  def nextDay()    = now() + 1.day
+  def nextWeek()   = now() + 1.week
+  def nextMonth()  = now() + 1.month
+  def nextYear()   = now() + 1.year
+  def tomorrow()   = nextDay()
 
-  def lastSecond() = now - 1.second
-  def lastMinute() = now - 1.minute
-  def lastHour()   = now - 1.hour
-  def lastDay()    = now - 1.day
-  def yesterday()  = now - 1.day
-  def lastWeek()   = now - 1.week
-  def lastMonth()  = now - 1.month
-  def lastYear()   = now - 1.year
+  def lastSecond() = now() - 1.second
+  def lastMinute() = now() - 1.minute
+  def lastHour()   = now() - 1.hour
+  def lastDay()    = now() - 1.day
+  def lastWeek()   = now() - 1.week
+  def lastMonth()  = now() - 1.month
+  def lastYear()   = now() - 1.year
+  def yesterday()  = lastDay()
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticDateTimeFormat.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticDateTimeFormat.scala
@@ -19,25 +19,27 @@ package com.github.nscala_time.time
 import java.util.Locale
 import org.joda.time.format._
 
-object StaticDateTimeFormat extends StaticDateTimeFormat
+private[time] object StaticDateTimeFormat extends StaticDateTimeFormat
 
-trait StaticDateTimeFormat {
-  def forPattern(pattern: String): DateTimeFormatter =
-    DateTimeFormat.forPattern(pattern)
-  def forStyle(style: String): DateTimeFormatter =
-    DateTimeFormat.forStyle(style)
-  def fullDate(): DateTimeFormatter = DateTimeFormat.fullDate()
+private[time] trait StaticDateTimeFormat {
+  def forPattern(pattern: String): DateTimeFormatter = DateTimeFormat.forPattern(pattern)
+  def forStyle(style: String): DateTimeFormatter     = DateTimeFormat.forStyle(style)
+
+  def fullDate(): DateTimeFormatter     = DateTimeFormat.fullDate()
   def fullDateTime(): DateTimeFormatter = DateTimeFormat.fullDateTime()
-  def fullTime(): DateTimeFormatter = DateTimeFormat.fullTime()
-  def longDate(): DateTimeFormatter = DateTimeFormat.longDate()
+  def fullTime(): DateTimeFormatter     = DateTimeFormat.fullTime()
+
+  def longDate(): DateTimeFormatter     = DateTimeFormat.longDate()
   def longDateTime(): DateTimeFormatter = DateTimeFormat.longDateTime()
-  def longTime(): DateTimeFormatter = DateTimeFormat.longTime()
-  def mediumDate(): DateTimeFormatter = DateTimeFormat.mediumDate()
+  def longTime(): DateTimeFormatter     = DateTimeFormat.longTime()
+
+  def mediumDate(): DateTimeFormatter     = DateTimeFormat.mediumDate()
   def mediumDateTime(): DateTimeFormatter = DateTimeFormat.mediumDateTime()
-  def mediumTime(): DateTimeFormatter = DateTimeFormat.mediumTime()
-  def patternForStyle(style: String, locale: Locale): String =
-    DateTimeFormat.patternForStyle(style, locale)
-  def shortDate(): DateTimeFormatter = DateTimeFormat.shortDate()
+  def mediumTime(): DateTimeFormatter     = DateTimeFormat.mediumTime()
+
+  def patternForStyle(style: String, locale: Locale): String = DateTimeFormat.patternForStyle(style, locale)
+
+  def shortDate(): DateTimeFormatter     = DateTimeFormat.shortDate()
   def shortDateTime(): DateTimeFormatter = DateTimeFormat.shortDateTime()
-  def shortTime(): DateTimeFormatter = DateTimeFormat.shortTime()
+  def shortTime(): DateTimeFormatter     = DateTimeFormat.shortTime()
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticDateTimeZone.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticDateTimeZone.scala
@@ -18,22 +18,23 @@ package com.github.nscala_time.time
 
 import org.joda.time._
 
-object StaticDateTimeZone extends StaticDateTimeZone
+private[time] object StaticDateTimeZone extends StaticDateTimeZone
 
-trait StaticDateTimeZone {
+private[time] trait StaticDateTimeZone {
   lazy val UTC = DateTimeZone.UTC
-  def forID(id: String) = DateTimeZone.forID(id)
-  def forOffsetHours(hours: Int) = DateTimeZone.forOffsetHours(hours)
-  def forOffsetHoursMinutes(hours: Int, minutes: Int) =
-    DateTimeZone.forOffsetHoursMinutes(hours, minutes)
-  def forOffsetMillis(millis: Int) = DateTimeZone.forOffsetMillis(millis)
-  def forTimeZone(zone: java.util.TimeZone) = DateTimeZone.forTimeZone(zone)
-  def getAvailableIDs() = DateTimeZone.getAvailableIDs()
-  def getDefault() = DateTimeZone.getDefault()
-  def getNameProvider() = DateTimeZone.getNameProvider()
-  def getProvider() = DateTimeZone.getProvider()
-  def setDefault(zone: DateTimeZone) = DateTimeZone.setDefault(zone)
-  def setNameProvider(nameProvider: tz.NameProvider) =
-    DateTimeZone.setNameProvider(nameProvider)
-  def setProvider(provider: tz.Provider) = DateTimeZone.setProvider(provider)
+
+  def forID(id: String)                               = DateTimeZone.forID(id)
+  def forOffsetHours(hours: Int)                      = DateTimeZone.forOffsetHours(hours)
+  def forOffsetHoursMinutes(hours: Int, minutes: Int) = DateTimeZone.forOffsetHoursMinutes(hours, minutes)
+  def forOffsetMillis(millis: Int)                    = DateTimeZone.forOffsetMillis(millis)
+  def forTimeZone(zone: java.util.TimeZone)           = DateTimeZone.forTimeZone(zone)
+
+  def getAvailableIDs = DateTimeZone.getAvailableIDs
+  def getDefault      = DateTimeZone.getDefault
+  def getNameProvider = DateTimeZone.getNameProvider
+  def getProvider     = DateTimeZone.getProvider
+
+  def setDefault(zone: DateTimeZone)                 = DateTimeZone.setDefault(zone)
+  def setNameProvider(nameProvider: tz.NameProvider) = DateTimeZone.setNameProvider(nameProvider)
+  def setProvider(provider: tz.Provider)             = DateTimeZone.setProvider(provider)
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticDuration.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticDuration.scala
@@ -18,13 +18,13 @@ package com.github.nscala_time.time
 
 import org.joda.time._
 
-object StaticDuration extends StaticDuration
+private[time] object StaticDuration extends StaticDuration
 
-trait StaticDuration {
-  def parse(str: String) = Duration.parse(str)
-  def standardDays(days: Long) = Duration.standardDays(days)
-  def standardHours(hours: Long) = Duration.standardHours(hours)
+private[time] trait StaticDuration {
+  def parse(str: String)             = Duration.parse(str)
+  def standardDays(days: Long)       = Duration.standardDays(days)
+  def standardHours(hours: Long)     = Duration.standardHours(hours)
   def standardMinutes(minutes: Long) = Duration.standardMinutes(minutes)
   def standardSeconds(seconds: Long) = Duration.standardSeconds(seconds)
-  def millis(millis: Long) = Duration.millis(millis)
+  def millis(millis: Long)           = Duration.millis(millis)
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticInterval.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticInterval.scala
@@ -19,35 +19,35 @@ package com.github.nscala_time.time
 import com.github.nscala_time.time.Implicits._
 import org.joda.time.Interval
 
-object StaticInterval extends StaticInterval
+private[time] object StaticInterval extends StaticInterval
 
-trait StaticInterval {
+private[time] trait StaticInterval {
   def parse(str: String) = Interval.parse(str)
 
-  def thisSecond() = StaticDateTime.now.second.interval
-  def thisMinute() = StaticDateTime.now.minute.interval
-  def thisHour()   = StaticDateTime.now.hour.interval
-  def thisDay()    = StaticDateTime.now.day.interval
-  def today()      = StaticDateTime.now.day.interval
-  def thisWeek()   = StaticDateTime.now.week.interval
-  def thisMonth()  = StaticDateTime.now.month.interval
-  def thisYear()   = StaticDateTime.now.year.interval
+  def thisSecond() = StaticDateTime.now().second.interval
+  def thisMinute() = StaticDateTime.now().minute.interval
+  def thisHour()   = StaticDateTime.now().hour.interval
+  def thisDay()    = StaticDateTime.now().day.interval
+  def thisWeek()   = StaticDateTime.now().week.interval
+  def thisMonth()  = StaticDateTime.now().month.interval
+  def thisYear()   = StaticDateTime.now().year.interval
+  def today()      = thisDay()
 
-  def nextSecond() = StaticDateTime.nextSecond.second.interval
-  def nextMinute() = StaticDateTime.nextMinute.minute.interval
-  def nextHour()   = StaticDateTime.nextHour.hour.interval
-  def nextDay()    = StaticDateTime.nextDay.day.interval
-  def tomorrow()   = StaticDateTime.nextDay.day.interval
-  def nextWeek()   = StaticDateTime.nextWeek.week.interval
-  def nextMonth()  = StaticDateTime.nextMonth.month.interval
-  def nextYear()   = StaticDateTime.nextYear.year.interval
+  def nextSecond() = StaticDateTime.nextSecond().second.interval
+  def nextMinute() = StaticDateTime.nextMinute().minute.interval
+  def nextHour()   = StaticDateTime.nextHour().hour.interval
+  def nextDay()    = StaticDateTime.nextDay().day.interval
+  def nextWeek()   = StaticDateTime.nextWeek().week.interval
+  def nextMonth()  = StaticDateTime.nextMonth().month.interval
+  def nextYear()   = StaticDateTime.nextYear().year.interval
+  def tomorrow()   = nextDay()
 
-  def lastSecond() = StaticDateTime.lastSecond.second.interval
-  def lastMinute() = StaticDateTime.lastMinute.minute.interval
-  def lastHour()   = StaticDateTime.lastHour.hour.interval
-  def lastDay()    = StaticDateTime.lastDay.day.interval
-  def yesterday()  = StaticDateTime.lastDay.day.interval
-  def lastWeek()   = StaticDateTime.lastWeek.week.interval
-  def lastMonth()  = StaticDateTime.lastMonth.month.interval
-  def lastYear()   = StaticDateTime.lastYear.year.interval
+  def lastSecond() = StaticDateTime.lastSecond().second.interval
+  def lastMinute() = StaticDateTime.lastMinute().minute.interval
+  def lastHour()   = StaticDateTime.lastHour().hour.interval
+  def lastDay()    = StaticDateTime.lastDay().day.interval
+  def lastWeek()   = StaticDateTime.lastWeek().week.interval
+  def lastMonth()  = StaticDateTime.lastMonth().month.interval
+  def lastYear()   = StaticDateTime.lastYear().year.interval
+  def yesterday()  = lastDay()
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticLocalDate.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticLocalDate.scala
@@ -22,20 +22,19 @@ import org.joda.time._
 import com.github.nscala_time.time.Implicits._
 import org.joda.time.format.DateTimeFormatter
 
-object StaticLocalDate extends StaticLocalDate 
+private[time] object StaticLocalDate extends StaticLocalDate
 
-trait StaticLocalDate {
+private[time] trait StaticLocalDate {
   type Property = LocalDate.Property
   
-  def fromCalendarFields(calendar: Calendar) =
-    LocalDate.fromCalendarFields(calendar)
-  def fromDateFields(date: Date) =
-    LocalDate.fromDateFields(date)
+  def fromCalendarFields(calendar: Calendar) = LocalDate.fromCalendarFields(calendar)
+  def fromDateFields(date: Date)             = LocalDate.fromDateFields(date)
   
-  def now()        = new LocalDate
-  def now(zone: DateTimeZone) = LocalDate.now(zone)
+  def now()                       = new LocalDate
+  def now(zone: DateTimeZone)     = LocalDate.now(zone)
   def now(chronology: Chronology) = LocalDate.now(chronology)
-  def today()      = new LocalDate
+
+  def today() = new LocalDate
   def parse(str: String) = LocalDate.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = LocalDate.parse(str, formatter)
 

--- a/src/main/scala/com/github/nscala_time/time/StaticLocalDateTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticLocalDateTime.scala
@@ -21,19 +21,18 @@ import org.joda.time._
 import com.github.nscala_time.time.Implicits._
 import org.joda.time.format.DateTimeFormatter
 
-object StaticLocalDateTime extends StaticLocalDateTime
+private[time] object StaticLocalDateTime extends StaticLocalDateTime
 
-trait StaticLocalDateTime {
+private[time] trait StaticLocalDateTime {
   type Property = LocalDateTime.Property
   
-  def fromCalendarFields(calendar: Calendar) =
-    LocalDateTime.fromCalendarFields(calendar)
-  def fromDateFields(date: Date) =
-    LocalDateTime.fromDateFields(date)
+  def fromCalendarFields(calendar: Calendar) = LocalDateTime.fromCalendarFields(calendar)
+  def fromDateFields(date: Date)             = LocalDateTime.fromDateFields(date)
 
-  def now()        = new LocalDateTime
-  def now(zone: DateTimeZone) = LocalDateTime.now(zone)
+  def now()                       = new LocalDateTime
+  def now(zone: DateTimeZone)     = LocalDateTime.now(zone)
   def now(chronology: Chronology) = LocalDateTime.now(chronology)
+
   def parse(str: String) = LocalDateTime.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = LocalDateTime.parse(str, formatter)
 

--- a/src/main/scala/com/github/nscala_time/time/StaticLocalTime.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticLocalTime.scala
@@ -22,26 +22,23 @@ import org.joda.time._
 import com.github.nscala_time.time.Implicits._
 import org.joda.time.format.DateTimeFormatter
 
-object StaticLocalTime extends StaticLocalTime
+private[time] object StaticLocalTime extends StaticLocalTime
 
-trait StaticLocalTime {
+private[time] trait StaticLocalTime {
   type Property = LocalTime.Property
   
   final val MIDNIGHT = LocalTime.MIDNIGHT
   final val Midnight = LocalTime.MIDNIGHT
   
-  def fromCalendarFields(calendar: Calendar) =
-    LocalTime.fromCalendarFields(calendar)
-  def fromDateFields(date: Date) =
-    LocalTime.fromDateFields(date)
-  def fromMillisOfDay(millis: Long) =
-    LocalTime.fromMillisOfDay(millis)
-  def fromMillisOfDay(millis: Long, chrono: Chronology) =
-    LocalTime.fromMillisOfDay(millis, chrono)
+  def fromCalendarFields(calendar: Calendar)            = LocalTime.fromCalendarFields(calendar)
+  def fromDateFields(date: Date)                        = LocalTime.fromDateFields(date)
+  def fromMillisOfDay(millis: Long)                     = LocalTime.fromMillisOfDay(millis)
+  def fromMillisOfDay(millis: Long, chrono: Chronology) = LocalTime.fromMillisOfDay(millis, chrono)
 
-  def now()        = new LocalTime
-  def now(zone: DateTimeZone) = LocalTime.now(zone)
+  def now()                       = new LocalTime
+  def now(zone: DateTimeZone)     = LocalTime.now(zone)
   def now(chronology: Chronology) = LocalTime.now(chronology)
+
   def parse(str: String) = LocalTime.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = LocalTime.parse(str, formatter)
 

--- a/src/main/scala/com/github/nscala_time/time/StaticMonthDay.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticMonthDay.scala
@@ -20,16 +20,18 @@ import org.joda.time._
 import org.joda.time.format.DateTimeFormatter
 import java.util.{Calendar, Date}
 
-object StaticMonthDay extends StaticMonthDay
+private[time] object StaticMonthDay extends StaticMonthDay
 
-trait StaticMonthDay {
+private[time] trait StaticMonthDay {
   type Property = MonthDay.Property
 
   def fromCalendarFields(calendar: Calendar) = MonthDay.fromCalendarFields(calendar)
   def fromDateFields(date: Date) = MonthDay.fromDateFields(date)
-  def now() = MonthDay.now()
+
+  def now()                       = MonthDay.now()
   def now(chronology: Chronology) = MonthDay.now(chronology)
-  def now(zone: DateTimeZone) = MonthDay.now(zone)
+  def now(zone: DateTimeZone)     = MonthDay.now(zone)
+
   def parse(str: String) = MonthDay.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = MonthDay.parse(str, formatter)
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticPartial.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticPartial.scala
@@ -18,8 +18,8 @@ package com.github.nscala_time.time
 
 import org.joda.time._
 
-object StaticPartial extends StaticPartial
+private[time] object StaticPartial extends StaticPartial
 
-trait StaticPartial {
+private[time] trait StaticPartial {
   type Property = Partial.Property
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticPeriod.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticPeriod.scala
@@ -19,20 +19,19 @@ package com.github.nscala_time.time
 import org.joda.time._
 import org.joda.time.format.PeriodFormatter
 
-object StaticPeriod extends StaticPeriod
+private[time] object StaticPeriod extends StaticPeriod
 
-trait StaticPeriod {
+private[time] trait StaticPeriod {
   def parse(str: String) = Period.parse(str)
   def parse(str: String, formatter: PeriodFormatter) = Period.parse(str, formatter)
+  def fieldDifference(start: ReadablePartial, end: ReadablePartial) = Period.fieldDifference(start, end)
 
-  def days(days: Int) = Period.days(days)
-  def fieldDifference(start: ReadablePartial, end: ReadablePartial) =
-    Period.fieldDifference(start, end)
-  def hours(hours: Int) = Period.hours(hours)
-  def millis(millis: Int) = Period.millis(millis)
+  def days(days: Int)       = Period.days(days)
+  def hours(hours: Int)     = Period.hours(hours)
+  def millis(millis: Int)   = Period.millis(millis)
   def minutes(minutes: Int) = Period.minutes(minutes)
-  def months(months: Int) = Period.months(months)
+  def months(months: Int)   = Period.months(months)
   def seconds(seconds: Int) = Period.seconds(seconds)
-  def weeks(weeks: Int) = Period.weeks(weeks)
-  def years(years: Int) = Period.years(years)
+  def weeks(weeks: Int)     = Period.weeks(weeks)
+  def years(years: Int)     = Period.years(years)
 }

--- a/src/main/scala/com/github/nscala_time/time/StaticYearMonth.scala
+++ b/src/main/scala/com/github/nscala_time/time/StaticYearMonth.scala
@@ -20,16 +20,18 @@ import org.joda.time._
 import org.joda.time.format.DateTimeFormatter
 import java.util.{Calendar, Date}
 
-object StaticYearMonth extends StaticYearMonth
+private[time] object StaticYearMonth extends StaticYearMonth
 
-trait StaticYearMonth {
-  type Property = YearMonth.Property
+private[time] trait StaticYearMonth {
+  private[this] type Property = YearMonth.Property
 
   def fromCalendarFields(calendar: Calendar) = YearMonth.fromCalendarFields(calendar)
-  def fromDateFields(date: Date) = YearMonth.fromDateFields(date)
-  def now() = YearMonth.now()
+  def fromDateFields(date: Date)             = YearMonth.fromDateFields(date)
+
+  def now()                       = YearMonth.now()
   def now(chronology: Chronology) = YearMonth.now(chronology)
-  def now(zone: DateTimeZone) = YearMonth.now(zone)
+  def now(zone: DateTimeZone)     = YearMonth.now(zone)
+
   def parse(str: String) = YearMonth.parse(str)
   def parse(str: String, formatter: DateTimeFormatter) = YearMonth.parse(str, formatter)
 }


### PR DESCRIPTION
(1) Adds `()` to code that using the function like functions `now()`, `nextSecond()`, etc;
(2) Fomats the source code;
(3) Adds `private[time]` to related wrapper classes, like `RichXXX`, `StaticYYY`.

I think the classed like `RichXXX`, `StaticYYY` should not be accessed by user, so I add `private[time]`.
This is the first time that I take part in Github. Please review this revision.
  